### PR TITLE
Trivial: %d shown in exception message

### DIFF
--- a/p4api.net/P4Server.cs
+++ b/p4api.net/P4Server.cs
@@ -1111,7 +1111,7 @@ namespace Perforce.P4
                             foreach (P4ClientError e in _errorList)
                             {
                                 if (e.ErrorCode == P4ClientError.MsgRpc_Break)
-                                    throw new P4CommandCanceledException(String.Format("Command %d cancelled", cmdId));
+                                    throw new P4CommandCanceledException(String.Format("Command {0} cancelled", cmdId));
                             }
                             P4Exception.Throw(cmd, args, _errorList, GetInfoResults(cmdId));
                         }


### PR DESCRIPTION
P4CommandCanceledException in P4Server's RunCommand used a C style %d in
the sting.Format rather than the C# style {0} (or {cmdId:d}