### PR TITLE
Update P4BridgeServer.cpp for crash fix

### DIFF
--- a/p4bridge/P4BridgeServer.cpp
+++ b/p4bridge/P4BridgeServer.cpp
@@ -942,13 +942,7 @@ int P4BridgeServer::run_command( const char *cmd, int cmdId, int tagged, char **
 		}
 		if (idx2 < idx1)
 		{
-			pProgramName = new char[(idx1 - idx2) + 1];
-			idx1 = idx2;
-			while ((idx1 < MAX_PATH) && (pModPath[idx1] != '\0'))
-			{
-				pProgramName[idx1-idx2] = pModPath[idx1++];
-			}
-			pProgramName[idx1-idx2] = '\0';
+			pProgramName = pModPath + idx2;
 		}
 	}
 	DELETE_ARRAY(pModPath);


### PR DESCRIPTION
The p4bridge expriences a crash when the application name is over 16 characters long. This is because pProgramName has been changed from a char * to a std::string. The std::string is only 16 bytes in length. So any application that we have that's more than 16 characters in length is memory stomping the string.