### PR TITLE
Fix Crash due to GetExecutingAssembly Location returns empty string

### DIFF
--- a/p4api.net/P4Bridge.cs
+++ b/p4api.net/P4Bridge.cs
@@ -59,7 +59,7 @@ namespace Perforce.P4
         {
             IntPtr libHandle = IntPtr.Zero;
 
-            string assemblyDirectory = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+            string assemblyDirectory = AppContext.BaseDirectory;
 
             // Look first in the location we expect for the nuget package,
             // if not found, look within the Assembly runtime directory


### PR DESCRIPTION
In .NET 5 and later versions, for bundled assemblies, the value returned is an empty string and the first parameter of Path.Combine cannot be empty.

https://learn.microsoft.com/en-us/dotnet/api/system.reflection.assembly.location?view=net-5.0#System_Reflection_Assembly_Location

It is enough to use AppContext.BaseDirectory.