### PR TITLE
Enabling GetChangelists() to use @ to search range of changelists

### DIFF
--- a/p4api.net/Repository.Changelist.cs
+++ b/p4api.net/Repository.Changelist.cs
@@ -1293,7 +1293,7 @@ namespace Perforce.P4
         public IList<Changelist> GetChangelists(Options options, params FileSpec[] files)
 		{
             using (P4Command cmd = (files?.Length ?? 0) > 0
-                ? new P4Command(this, "changes", true, FileSpec.ToEscapedStrings(files))
+                ? new P4Command(this, "changes", true, FileSpec.ToStrings(files))
                 : new P4Command(this, "changes", true))
 			{
 


### PR DESCRIPTION
Hi,

We are trying to use p4api.net in our service and found a blocking issue.

Currently, getting changelists from #id to #id is not possible.
Because of FileSpec.ToEscapedStrings() which converts "@" to "%40" and breaks the p4command
ex) p4 changes //...@1,7

Is there a way to make this possible?
If not, could you support this one?

Thanks.


Minsu Kim
Email: minsu.kim@ubisoft.com